### PR TITLE
fix: follow label width when fullWidth prop is true

### DIFF
--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -32,3 +32,27 @@ export const Primary: ComponentStory<typeof MuiFileInput> = () => {
     </ThemeProvider>
   )
 }
+
+export const FullWidth: ComponentStory<typeof MuiFileInput> = () => {
+  const [value, setValue] = React.useState<File[]>([])
+
+  const handleChange = (newValue: File[]) => {
+    setValue(newValue)
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <MuiFileInput
+        fullWidth
+        placeholder="Choisir un fichier"
+        inputProps={{
+          accept: 'video/*'
+        }}
+        multiple
+        value={value}
+        onChange={handleChange}
+        label="fullWidth"
+      />
+    </ThemeProvider>
+  )
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,6 +114,7 @@ function MuiFileInput<T extends boolean = false>(props: MuiFileInputProps<T>) {
 
   return (
     <TextField
+      sx={{ '& .MuiInputBase-root label': { width: '100%' } }}
       type="file"
       disabled={disabled}
       onChange={handleChange}


### PR DESCRIPTION
This PR solves https://github.com/viclafouch/mui-file-input/issues/9 .
It seems that the `TextField` component's `InputLabelProps` prop etc. cannot control the style of the label element, so I'm using the `sx` prop.
If the quality is unsatisfactory, please close.