### PR TITLE
Add "types" to "exports", to make typescript happy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/mui-file-input.es.js",
       "require": "./dist/mui-file-input.umd.js"
     }


### PR DESCRIPTION
It appears for later versions of typescript (I'm under the impression its v5 and up, but I don't know for sure), if the package.json has a "exports" field, the relevant "types" field has to be inside the exports field too.