### PR TITLE
Update Typescript example

### DIFF
--- a/docs/docs/typescript.md
+++ b/docs/docs/typescript.md
@@ -15,7 +15,7 @@ import { MuiFileInput } from 'mui-file-input'
 const MyComponent = () => {
   const [value, setValue] = React.useState<File | null>(null)
 
-  const handleChange = (newValue: File) => {
+  const handleChange = (newValue: File | null) => {
     setValue(newValue)
   }
 


### PR DESCRIPTION
Previously, when copying the example into an IDE, the TS compiler would throw an error since the 'onChange' function emits a value that can be null. This change fixes that error.