### PR TITLE
Add hideIcon option

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -79,6 +79,17 @@ In case you do not want to display the size of the current value.
 <MuiFileInput hideSizeText />
 ```
 
+## `hideIcon`
+
+- Type: `boolean`
+- Default: `false`
+
+In case you do not want to display the icon.
+
+```tsx
+<MuiFileInput hideIcon />
+```
+
 ## `getInputText`
 
 - Type: `(value: File | null) => string`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,7 @@ const MuiFileInput = <T extends boolean | undefined>(
     getSizeText,
     placeholder,
     hideSizeText,
+    hideIcon,
     inputProps,
     InputProps,
     multiple,
@@ -131,10 +132,12 @@ const MuiFileInput = <T extends boolean | undefined>(
       onChange={handleChange}
       className={`MuiFileInput-TextField ${className || ''}`}
       InputProps={{
-        startAdornment: (
+        startAdornment: !hideIcon ? (
           <InputAdornment position="start">
             <AttachFileIcon />
           </InputAdornment>
+        ) : (
+          <> </>
         ),
         endAdornment: (
           <InputAdornment

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -9,6 +9,7 @@ export type MuiFileInputProps<T extends boolean | undefined> =
   TextFieldProps & {
     value?: T extends true ? File[] : File | null
     hideSizeText?: boolean
+    hideIcon?: boolean
     multiple?: T
     getInputText?: (files: T extends true ? File[] : File | null) => string
     getSizeText?: (files: T extends true ? File[] : File | null) => string


### PR DESCRIPTION
This PR adds an option called `hideIcon`. if you enable this option, `AttachFileIcon` will not be display

And I have also added a desecription of this option in docs