### PR TITLE
move exports default to the end

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "exports": {
     ".": {
       "import": "./dist/mui-file-input.es.js",
-      "default": "./dist/mui-file-input.es.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/mui-file-input.es.js"
     }
   },
   "repository": {


### PR DESCRIPTION
This is an error I got in nextjs:

```
Module not found: Default condition should be last one
```