### PR TITLE
fix: first child error

### DIFF
--- a/src/components/Input/Input.styled.ts
+++ b/src/components/Input/Input.styled.ts
@@ -32,13 +32,13 @@ const Filename = styled('div')`
     display: block;
   }
 
-  & > span:first-child {
+  & > span:first-of-type {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
   }
 
-  & > span:last-child {
+  & > span:last-of-type {
     flex-shrink: 0;
     display: block;
   }


### PR DESCRIPTION
I had the following error 

<img width="499" alt="Screenshot 2023-09-07 alle 10 24 34" src="https://github.com/viclafouch/mui-file-input/assets/44018650/bd730ffb-cf09-45f2-ba47-64a5a66b6743">

I tried also in storybook and I had the same error.
I saw that there was issue #35 and using @daturon code I fixed the error. 

Hoping to have done a good thing