### PR TITLE
feat: Add closeButtonProps to MuiFileInput component

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -103,3 +103,15 @@ Customize the render text inside the size Typography.
 <MuiFileInput getSizeText={(value) => 'Very big'} />
 ```
 
+## `closeButtonProps`
+
+- Type: `IconButtonProps`
+- Default: `undefined`
+
+Override the close button.
+
+Check here to check out all IconButtonProps : https://mui.com/material-ui/api/icon-button/
+
+```tsx
+<MuiFileInput closeButtonProps={{ title: "Remove" }} />
+```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -156,7 +156,7 @@ const MuiFileInput = <T extends boolean | undefined>(
               title="Clear"
               size="small"
               disabled={disabled}
-              className="MuiFileInput-IconButton"
+              className={`${closeButtonProps?.className} MuiFileInput-IconButton`}
               onClick={handleClearAll}
               {...closeButtonProps}
             >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,7 @@ const MuiFileInput = <T extends boolean | undefined>(
     InputProps,
     multiple,
     className,
+    closeButtonProps,
     ...restTextFieldProps
   } = props
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -157,6 +158,7 @@ const MuiFileInput = <T extends boolean | undefined>(
               disabled={disabled}
               className="MuiFileInput-IconButton"
               onClick={handleClearAll}
+              {...closeButtonProps}
             >
               <CloseIcon fontSize="small" />
             </IconButton>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,7 @@ const MuiFileInput = <T extends boolean | undefined>(
     closeButtonProps,
     ...restTextFieldProps
   } = props
+  const { className: iconButtonClassName = '', ...restIconButtonProps } = closeButtonProps
   const inputRef = React.useRef<HTMLInputElement>(null)
   const isMultiple =
     multiple ||
@@ -156,9 +157,9 @@ const MuiFileInput = <T extends boolean | undefined>(
               title="Clear"
               size="small"
               disabled={disabled}
-              className={`${closeButtonProps?.className} MuiFileInput-IconButton`}
+              className={`${iconButtonClassName} MuiFileInput-IconButton`}
               onClick={handleClearAll}
-              {...closeButtonProps}
+              {...restIconButtonProps}
             >
               <CloseIcon fontSize="small" />
             </IconButton>

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -1,3 +1,4 @@
+import { IconButtonProps } from '@mui/material/IconButton'
 import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField'
 
 type TextFieldProps = Omit<
@@ -13,4 +14,5 @@ export type MuiFileInputProps<T extends boolean | undefined> =
     getInputText?: (files: T extends true ? File[] : File | null) => string
     getSizeText?: (files: T extends true ? File[] : File | null) => string
     onChange?: (value: T extends true ? File[] : File | null) => void
+    closeButtonProps?: IconButtonProps
   }


### PR DESCRIPTION
Fixes: #41 

- Added closeButtonProps to MuiFileInput component in order to override the close button.