### PR TITLE
Migrate to MUI material V7, including inputProps to SlotProps

### DIFF
--- a/docs/docs/Migrations/migrate-v7-to-v8.md
+++ b/docs/docs/Migrations/migrate-v7-to-v8.md
@@ -1,0 +1,33 @@
+# Migrate from v7 to v8
+
+Version 8 of this library only supports MUI material v7, and now instead it supports "slotProps" instead of the deprecated "InputProps".
+
+## InputProps to SlotProps migration
+
+In MUI v6, the `InputProps` prop has been deprecated in favor of `slotProps`.
+
+```tsx
+// Before (MUI v6)
+<MuiFileInput
+  InputProps={{
+    startAdornment: <AttachFileIcon />,
+    inputProps: {
+      accept: 'video/*'
+    }
+  }}
+/>
+
+// After (MUI v7)
+<MuiFileInput
+  slotProps={{
+    htmlInput: {
+      accept: 'video/*'
+    },
+    input: {
+      startAdornment: <AttachFileIcon />,
+    }
+  }}
+/>
+```
+
+For more information see the MUI docs: https://mui.com/material-ui/migration/migrating-from-deprecated-apis/#props-props-2

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -40,7 +40,7 @@ const handleChange = (value) => {}
 <MuiFileInput onChange={handleChange} />
 ```
 
-## `inputProps => accept`
+## `slotProps.htmlInput => accept`
 
 - Type: `string | undefined`
 - Default: `undefined`
@@ -50,9 +50,9 @@ Check here for more info : https://developer.mozilla.org/en-US/docs/Web/HTML/Att
 
 ```tsx
 // TS will throw an error if the value is a single File instead of an array of Files.
-<MuiFileInput inputProps={{ accept: 'video/*' }} />
-<MuiFileInput inputProps={{ accept: '.png, .jpeg' }} />
-<MuiFileInput inputProps={{ accept: 'audio/*, .pdf' }} />
+<MuiFileInput slotProps={{ htmlInput: { accept: 'video/*' } }} />
+<MuiFileInput slotProps={{ htmlInput: { accept: '.png, .jpeg' } }} />
+<MuiFileInput slotProps={{ htmlInput: { accept: 'audio/*, .pdf' } }} />
 ```
 
 ## `multiple`

--- a/docs/docs/inheritance.md
+++ b/docs/docs/inheritance.md
@@ -18,11 +18,13 @@ import AttachFileIcon from '@mui/icons-material/AttachFile'
   size="small"
   variant="outlined"
   disabled
-  InputProps={{
-    inputProps: {
+  slotProps={{
+    htmlInput: {
       accept: 'video/*'
     },
-    startAdornment: <AttachFileIcon />
+    input: {
+      startAdornment: <AttachFileIcon />
+    }
   }}
 />
 ```

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,9 +19,9 @@
     "@docusaurus/preset-classic": "3.7.0",
     "@docusaurus/tsconfig": "^3.7.0",
     "@mdx-js/react": "^3.1.0",
-    "@mui/icons-material": "^6.4.7",
+    "@mui/icons-material": "^7.0.2",
     "clsx": "^2.1.1",
-    "mui-file-input": "^7.0.0",
+    "mui-file-input": "^8.0.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -35,8 +35,10 @@ const HomepageHeader = () => {
           clearIconButtonProps={{
             children: <CloseIcon fontSize="small" />
           }}
-          InputProps={{
-            startAdornment: <AttachFileIcon />
+          slotProps={{
+            input: {
+              startAdornment: <AttachFileIcon />
+            }
           }}
         />
         <div className={styles.buttons}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mui-file-input",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mui-file-input",
-      "version": "7.0.0",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "pretty-bytes": "^6.1.1"
@@ -15,8 +15,8 @@
         "@babel/core": "^7.26.9",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@mui/icons-material": "^6.4.7",
-        "@mui/material": "^6.4.7",
+        "@mui/icons-material": "^7.0.0",
+        "@mui/material": "^7.0.0",
         "@storybook/addon-actions": "^8.6.4",
         "@storybook/addon-essentials": "^8.6.4",
         "@storybook/addon-interactions": "^8.6.4",
@@ -44,14 +44,14 @@
         "standard-version": "^9.5.0",
         "storybook": "^8.6.4",
         "typescript": "^5.5.4",
-        "vite": "^6.2.1",
+        "vite": "6.2.6",
         "vite-plugin-dts": "^4.5.3",
         "vitest": "^3.0.8"
       },
       "peerDependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "@mui/material": "^6.0.0",
+        "@mui/material": "^7.0.0",
         "@types/react": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1547,9 +1547,9 @@
       "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.7.tgz",
-      "integrity": "sha512-XjJrKFNt9zAKvcnoIIBquXyFyhfrHYuttqMsoDS7lM7VwufYG4fAPw4kINjBFg++fqXM2BNAuWR9J7XVIuKIKg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.0.2.tgz",
+      "integrity": "sha512-TfeFU9TgN1N06hyb/pV/63FfO34nijZRMqgHk0TJ3gkl4Fbd+wZ73+ZtOd7jag6hMmzO9HSrBc6Vdn591nhkAg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1558,13 +1558,13 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.4.7.tgz",
-      "integrity": "sha512-Rk8cs9ufQoLBw582Rdqq7fnSXXZTqhYRbpe1Y5SAz9lJKZP3CIdrj0PfG8HJLGw1hrsHFN/rkkm70IDzhJsG1g==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.0.2.tgz",
+      "integrity": "sha512-Bo57PFLOqXOqPNrXjd8AhzH5s6TCsNUQbvnQ0VKZ8D+lIlteqKnrk/O1luMJUc/BXONK7BfIdTdc7qOnXYbMdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0"
+        "@babel/runtime": "^7.27.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1574,7 +1574,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^6.4.7",
+        "@mui/material": "^7.0.2",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -1585,23 +1585,23 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.7.tgz",
-      "integrity": "sha512-K65StXUeGAtFJ4ikvHKtmDCO5Ab7g0FZUu2J5VpoKD+O6Y3CjLYzRi+TMlI3kaL4CL158+FccMoOd/eaddmeRQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.0.2.tgz",
+      "integrity": "sha512-rjJlJ13+3LdLfobRplkXbjIFEIkn6LgpetgU/Cs3Xd8qINCCQK9qXQIjjQ6P0FXFTPFzEVMj0VgBR1mN+FhOcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.4.7",
-        "@mui/system": "^6.4.7",
-        "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.4.6",
+        "@babel/runtime": "^7.27.0",
+        "@mui/core-downloads-tracker": "^7.0.2",
+        "@mui/system": "^7.0.2",
+        "@mui/types": "^7.4.1",
+        "@mui/utils": "^7.0.2",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
+        "react-is": "^19.1.0",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -1614,7 +1614,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.4.7",
+        "@mui/material-pigment-css": "^7.0.2",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1635,14 +1635,14 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.6.tgz",
-      "integrity": "sha512-T5FxdPzCELuOrhpA2g4Pi6241HAxRwZudzAuL9vBvniuB5YU82HCmrARw32AuCiyTfWzbrYGGpZ4zyeqqp9RvQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.0.2.tgz",
+      "integrity": "sha512-6lt8heDC9wN8YaRqEdhqnm0cFCv08AMf4IlttFvOVn7ZdKd81PNpD/rEtPGLLwQAFyyKSxBG4/2XCgpbcdNKiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.4.6",
+        "@babel/runtime": "^7.27.0",
+        "@mui/utils": "^7.0.2",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1663,13 +1663,13 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.6.tgz",
-      "integrity": "sha512-vSWYc9ZLX46be5gP+FCzWVn5rvDr4cXC5JBZwSIkYk9xbC7GeV+0kCvB8Q6XLFQJy+a62bbqtmdwS4Ghi9NBlQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.0.2.tgz",
+      "integrity": "sha512-11Bt4YdHGlh7sB8P75S9mRCUxTlgv7HGbr0UKz6m6Z9KLeiw1Bm9y/t3iqLLVMvSHYB6zL8X8X+LmfTE++gyBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
+        "@babel/runtime": "^7.27.0",
         "@emotion/cache": "^11.13.5",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -1698,17 +1698,17 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.7.tgz",
-      "integrity": "sha512-7wwc4++Ak6tGIooEVA9AY7FhH2p9fvBMORT4vNLMAysH3Yus/9B9RYMbrn3ANgsOyvT3Z7nE+SP8/+3FimQmcg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.0.2.tgz",
+      "integrity": "sha512-yFUraAWYWuKIISPPEVPSQ1NLeqmTT4qiQ+ktmyS8LO/KwHxB+NNVOacEZaIofh5x1NxY8rzphvU5X2heRZ/RDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.4.6",
-        "@mui/styled-engine": "^6.4.6",
-        "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.4.6",
+        "@babel/runtime": "^7.27.0",
+        "@mui/private-theming": "^7.0.2",
+        "@mui/styled-engine": "^7.0.2",
+        "@mui/types": "^7.4.1",
+        "@mui/utils": "^7.0.2",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1739,11 +1739,14 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.21",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.21.tgz",
-      "integrity": "sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.1.tgz",
+      "integrity": "sha512-gUL8IIAI52CRXP/MixT1tJKt3SI6tVv4U/9soFsTtAsHzaJQptZ42ffdHZV3niX1ei0aUgMvOxBBN0KYqdG39g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.0"
+      },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -1754,18 +1757,18 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.6.tgz",
-      "integrity": "sha512-43nZeE1pJF2anGafNydUcYFPtHwAqiBiauRtaMvurdrZI3YrUjHkAu43RBsxef7OFtJMXGiHFvq43kb7lig0sA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.0.2.tgz",
+      "integrity": "sha512-72gcuQjPzhj/MLmPHLCgZjy2VjOH4KniR/4qRtXTTXIEwbkgcN+Y5W/rC90rWtMmZbjt9svZev/z+QHUI4j74w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.21",
+        "@babel/runtime": "^7.27.0",
+        "@mui/types": "^7.4.1",
         "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
+        "react-is": "^19.1.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -10346,9 +10349,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
-      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "dev": true,
       "license": "MIT"
     },
@@ -12399,9 +12402,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.1.tgz",
-      "integrity": "sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/viclafouch/mui-file-input/issues"
   },
   "homepage": "https://viclafouch.github.io/mui-file-input",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "files": [
     "dist"
   ],
@@ -57,7 +57,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "@mui/material": "^6.0.0",
+    "@mui/material": "^7.0.0",
     "@types/react": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
@@ -74,8 +74,8 @@
     "@babel/core": "^7.26.9",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@mui/icons-material": "^6.4.7",
-    "@mui/material": "^6.4.7",
+    "@mui/icons-material": "^7.0.0",
+    "@mui/material": "^7.0.0",
     "@storybook/addon-actions": "^8.6.4",
     "@storybook/addon-essentials": "^8.6.4",
     "@storybook/addon-interactions": "^8.6.4",
@@ -103,7 +103,7 @@
     "standard-version": "^9.5.0",
     "storybook": "^8.6.4",
     "typescript": "^5.5.4",
-    "vite": "^6.2.1",
+    "vite": "6.2.6",
     "vite-plugin-dts": "^4.5.3",
     "vitest": "^3.0.8"
   }

--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -27,8 +27,10 @@ export const Primary: StoryFn<typeof MuiFileInput> = () => {
         clearIconButtonProps={{
           children: <CloseIcon fontSize="small" />
         }}
-        InputProps={{
-          startAdornment: <AttachFileIcon />
+        slotProps={{
+          input: {
+            startAdornment: <AttachFileIcon />
+          }
         }}
         required
         multiple

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,8 +29,7 @@ export const MuiFileInput = (props: MuiFileInputProps) => {
     placeholder,
     hideSizeText,
     ref,
-    inputProps,
-    InputProps,
+    slotProps,
     multiple,
     className,
     clearIconButtonProps = {},
@@ -39,11 +38,12 @@ export const MuiFileInput = (props: MuiFileInputProps) => {
   const { className: iconButtonClassName = '', ...restClearIconButtonProps } =
     clearIconButtonProps
   const inputRef = React.useRef<HTMLInputElement>(null)
-  const { startAdornment, ...restInputProps } = InputProps || {}
+  //@ts-expect-error
+  const { startAdornment } = slotProps?.input || {}
   const isMultiple =
     multiple ||
-    (inputProps?.multiple as boolean) ||
-    (InputProps?.inputProps?.multiple as boolean) ||
+    //@ts-expect-error
+    (slotProps?.htmlInput?.multiple as boolean) ||
     false
 
   const resetInputValue = () => {
@@ -144,48 +144,49 @@ export const MuiFileInput = (props: MuiFileInputProps) => {
       disabled={disabled}
       onChange={handleChange}
       className={`MuiFileInput-TextField ${className || ''}`}
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">{startAdornment}</InputAdornment>
-        ),
-        endAdornment: (
-          <InputAdornment
-            position="end"
-            style={{ visibility: hasAtLeastOneFile ? 'visible' : 'hidden' }}
-          >
-            {!hideSizeText ? (
-              <Typography
-                variant="caption"
-                mr="2px"
-                lineHeight={1}
-                className="MuiFileInput-Typography-size-text"
-              >
-                {getTotalSizeText()}
-              </Typography>
-            ) : null}
-            <IconButton
-              aria-label="Clear"
-              title="Clear"
-              size="small"
-              disabled={disabled}
-              className={`${iconButtonClassName} MuiFileInput-ClearIconButton`}
-              onClick={handleClearAll}
-              {...restClearIconButtonProps}
-            />
-          </InputAdornment>
-        ),
-        ...restInputProps,
-        inputProps: {
+      slotProps={{
+        htmlInput: {
           text: getTheInputText(),
           multiple: isMultiple,
           ref: inputRef,
           isPlaceholder: !hasAtLeastOneFile,
           placeholder,
-          ...inputProps,
-          ...InputProps?.inputProps
+          ...slotProps?.htmlInput
         },
-        // @ts-expect-error
-        inputComponent: Input
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">{startAdornment}</InputAdornment>
+          ),
+          endAdornment: (
+            <InputAdornment
+              position="end"
+              style={{ visibility: hasAtLeastOneFile ? 'visible' : 'hidden' }}
+            >
+              {!hideSizeText ? (
+                <Typography
+                  variant="caption"
+                  mr="2px"
+                  lineHeight={1}
+                  className="MuiFileInput-Typography-size-text"
+                >
+                  {getTotalSizeText()}
+                </Typography>
+              ) : null}
+              <IconButton
+                aria-label="Clear"
+                title="Clear"
+                size="small"
+                disabled={disabled}
+                className={`${iconButtonClassName} MuiFileInput-ClearIconButton`}
+                onClick={handleClearAll}
+                {...restClearIconButtonProps}
+              />
+            </InputAdornment>
+          ),
+          //@ts-expect-error
+          inputComponent: Input,
+          ...slotProps?.input
+        }
       }}
       {...restTextFieldProps}
     />

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -3,7 +3,13 @@ import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextFiel
 
 type TextFieldProps = Omit<
   MuiTextFieldProps,
-  'onChange' | 'select' | 'type' | 'multiline' | 'defaultValue'
+  | 'onChange'
+  | 'select'
+  | 'type'
+  | 'multiline'
+  | 'defaultValue'
+  | 'inputProps'
+  | 'InputProps'
 >
 
 type MultipleOrSingleFile =


### PR DESCRIPTION
Upgrades to MUI v7 in line with the other packages.

All though, inputProps was only deprecated in mui V6 and hasn't been removed yet in V7, we could still support it. It will most likely be removed in the next version.

Couldn't get the `startAdornment` typing with slotProps to work so I have added `//@ts-expect-error`

I have updated the docs, to use this new field but couldn't build docs with new version. So you will have to verify that.

You will also have to update the description of this repository.

Fixes #60 
Fixes #58 

